### PR TITLE
Export an express router instead of setup method

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+extends:
+- "homeoffice/config/default"
+
+env:
+  es6: true
+  node: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "4"
+  - "6"
+
+before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hmpo-govuk-template
+# hof-govuk-template
 
 Compiles govuk mustache template into a more usable format and provide middleware for use in apps.
 
@@ -21,20 +21,18 @@ Compiling the template to replace these placeholders with variables allows for t
 ## Installation
 
 ```
-npm install [--save] hmpo-govuk-template
+npm install [--save] hof-govuk-template
 ```
 
 ## Usage
 
-The compilation of the template is performed automatically as an npm postinstall hook.
-
-When used as part of an express app, a setup method is provided which will add a static-middleware (using [serve-static](https://www.npmjs.com/package/serve-static)) to serve the template assets without needing to copy them to any other location.
+When used as part of an express app, a middleware is returned which will add a static fileserver (using [serve-static](https://www.npmjs.com/package/serve-static)) to serve the template assets without needing to copy them to any other location.
 
 It will also add the template as a mustache partial with a name of "govuk-template".
 
 ### To configure express middleware
 ```
-require('hmpo-govuk-template').setup(app[, { ... options ...}]);
+app.use(require('hof-govuk-template')([options]);
 ```
 
 ### To use the mustache partial

--- a/build/.eslintrc
+++ b/build/.eslintrc
@@ -1,0 +1,5 @@
+extends:
+  ../.eslintrc
+
+rules:
+  'implicit-dependencies/no-implicit': [2, { dev: true }]

--- a/build/config.js
+++ b/build/config.js
@@ -1,3 +1,5 @@
+'use strict';
+/* eslint max-len: 0 */
 module.exports = {
   htmlLang: '{{htmlLang}}',
   assetPath: '{{govukAssetPath}}',

--- a/build/index.js
+++ b/build/index.js
@@ -1,13 +1,13 @@
-var Hogan = require('hogan.js'),
-    fs = require('fs'),
-    util = require('util'),
-    path = require('path'),
-    govukConfig = require('./config'),
-    compiledTemplate,
-    govukTemplate;
+'use strict';
 
-var template = require.resolve('govuk_template_mustache/views/layouts/govuk_template.html');
+const Hogan = require('hogan.js');
+const fs = require('fs');
+const path = require('path');
+const govukConfig = require('./config');
 
-govukTemplate = fs.readFileSync(template, { encoding : 'utf-8' });
-compiledTemplate = Hogan.compile(govukTemplate);
-fs.writeFileSync(path.resolve(__dirname, '../govuk_template.html'), compiledTemplate.render(govukConfig), { encoding : 'utf-8' });
+const template = require.resolve('govuk_template_mustache/views/layouts/govuk_template.html');
+
+const govukTemplate = fs.readFileSync(template, { encoding: 'utf-8' });
+const compiledTemplate = Hogan.compile(govukTemplate).render(govukConfig);
+const output = path.resolve(__dirname, '../govuk_template.html');
+fs.writeFileSync(output, compiledTemplate, { encoding: 'utf-8' });

--- a/example/index.js
+++ b/example/index.js
@@ -1,14 +1,16 @@
-var express = require('express');
+'use strict';
 
-var app = express();
+const path = require('path');
+const express = require('express');
 
-require('hmpo-govuk-template').setup(app);
+const app = express();
 
 app.engine('html', require('hogan-express'));
-app.set('view engine', 'html'); // Use .html extensions
-app.set('views', __dirname + '/views');
+app.set('view engine', 'html');
+app.set('views', path.resolve(__dirname, 'views'));
 
-app.get('*', function (req, res) {
+app.use(require('hmpo-govuk-template'));
+app.get('*', (req, res) => {
     res.render('index');
 });
 

--- a/example/index.js
+++ b/example/index.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const express = require('express');
+const template = require('hof-govuk-template');
 
 const app = express();
 
@@ -9,7 +10,7 @@ app.engine('html', require('hogan-express'));
 app.set('view engine', 'html');
 app.set('views', path.resolve(__dirname, 'views'));
 
-app.use(require('hof-govuk-template'));
+app.use(template());
 app.get('*', (req, res) => {
     res.render('index');
 });

--- a/example/index.js
+++ b/example/index.js
@@ -9,7 +9,7 @@ app.engine('html', require('hogan-express'));
 app.set('view engine', 'html');
 app.set('views', path.resolve(__dirname, 'views'));
 
-app.use(require('hmpo-govuk-template'));
+app.use(require('hof-govuk-template'));
 app.get('*', (req, res) => {
     res.render('index');
 });

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "^4.11.2",
-    "hof-govuk-template": "^1.0.0",
+    "hof-govuk-template": "^2.0.0",
     "hogan-express": "^0.5.2"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "^4.11.2",
-    "hmpo-govuk-template": "^0.0.1",
+    "hof-govuk-template": "^1.0.0",
     "hogan-express": "^0.5.2"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,22 +1,23 @@
-var path = require('path'),
-    servestatic = require('serve-static');
+'use strict';
 
-var basedir = path.dirname(require.resolve('govuk_template_mustache/package.json'));
+const path = require('path');
+const servestatic = require('serve-static');
+const Router = require('express').Router;
 
-module.exports = {
-    setup: function (app, options) {
+const basedir = path.dirname(require.resolve('govuk_template_mustache/package.json'));
 
-        options = options || {};
-        options.path = options.path || '/govuk-assets';
+module.exports = options => {
+  const router = new Router();
+  options = options || {};
+  options.path = options.path || '/govuk-assets';
 
-        app.use(options.path, servestatic(path.join(basedir, './assets'), options));
-        app.use(function (req, res, next) {
-            res.locals.govukAssetPath = req.baseUrl + options.path + '/';
-            res.locals.partials = res.locals.partials || {};
-            res.locals.partials['govuk-template'] = path.resolve(__dirname, './govuk_template');
-            next();
-        });
+  router.use(options.path, servestatic(path.join(basedir, './assets'), options));
+  router.use((req, res, next) => {
+    res.locals.govukAssetPath = req.baseUrl + options.path + '/';
+    res.locals.partials = res.locals.partials || {};
+    res.locals.partials['govuk-template'] = path.resolve(__dirname, './govuk_template');
+    next();
+  });
 
-    },
-    assetPath: path.join(basedir, './assets')
+  return router;
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "Compile govuk mustache template into a more usable format and provide middleware for use in apps",
   "scripts": {
-    "postinstall": "node ./build/index.js"
+    "lint": "eslint .",
+    "test": "npm run lint",
+    "prepublish": "node ./build/index.js"
   },
   "main": "index.js",
   "repository": {
@@ -17,8 +19,13 @@
   },
   "homepage": "https://github.com/UKHomeOfficeForms/hof-govuk-template",
   "dependencies": {
+    "express": "^4.15.2",
     "govuk_template_mustache": "^0.17.3",
-    "hogan.js": "3.0.2",
     "serve-static": "^1.10.3"
+  },
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-config-homeoffice": "^2.1.2",
+    "hogan.js": "3.0.2"
   }
 }


### PR DESCRIPTION
This makes the module signature more aligned with standard practices for express apps.

Additionally moves the compile step from postinstall to prepublish to reduce the load on clients at install time.

Adds eslint and travis.

This is a terrible PR because I got carried away es6-ifying the things. My bad.